### PR TITLE
Add reply and mention functionality to !slots command

### DIFF
--- a/src/functions/SlotsGame.js
+++ b/src/functions/SlotsGame.js
@@ -233,7 +233,10 @@ async function slotsCommand(bot, message, args, group) {
 		return new ReturnMessage({
 			chatId,
 			content: `❌ Você não tem moedinhas suficientes para jogar! \n\n🪙 Próxima moedinha em: *${waitTime}*`,
-			options: { quotedMessageId: message.origin?.id?._serialized }
+			options: {
+				quotedMessageId: message.origin?.id?._serialized,
+				evoReply: message.origin
+			}
 		});
 	}
 

--- a/src/functions/SlotsGame.js
+++ b/src/functions/SlotsGame.js
@@ -232,7 +232,8 @@ async function slotsCommand(bot, message, args, group) {
 		const waitTime = formatTimeString(nextRegen.secondsUntilNextCoin);
 		return new ReturnMessage({
 			chatId,
-			content: `❌ Você não tem moedinhas suficientes para jogar! \n\n🪙 Próxima moedinha em: *${waitTime}*`
+			content: `❌ Você não tem moedinhas suficientes para jogar! \n\n🪙 Próxima moedinha em: *${waitTime}*`,
+			options: { quotedMessageId: message.origin?.id?._serialized }
 		});
 	}
 
@@ -328,7 +329,8 @@ async function slotsCommand(bot, message, args, group) {
 
 	return new ReturnMessage({
 		chatId,
-		content: resultMessage
+		content: resultMessage,
+		options: { quotedMessageId: message.origin?.id?._serialized }
 	});
 }
 

--- a/src/functions/SlotsGame.js
+++ b/src/functions/SlotsGame.js
@@ -333,7 +333,10 @@ async function slotsCommand(bot, message, args, group) {
 	return new ReturnMessage({
 		chatId,
 		content: resultMessage,
-		options: { quotedMessageId: message.origin?.id?._serialized }
+		options: {
+			quotedMessageId: message.origin?.id?._serialized,
+			evoReply: message.origin
+		}
 	});
 }
 


### PR DESCRIPTION
This pull request updates the `slotsCommand` function in `src/functions/SlotsGame.js` to improve message context handling. Now, when the bot sends a response, it includes the quoted message ID, allowing replies to be threaded or associated with the original user message.

**Message context improvements:**

* Updated both insufficient coins and result messages to include the `options` field with the `quotedMessageId`, referencing the original message. [[1]](diffhunk://#diff-bbe95b4ae1b8899165f3cb917394d424469e996e100b4565d833ffb42371e278L235-R236) [[2]](diffhunk://#diff-bbe95b4ae1b8899165f3cb917394d424469e996e100b4565d833ffb42371e278L331-R333)