### PR TITLE
Fix circular dependency between SlotsGame and FishingGame

### DIFF
--- a/src/functions/FishingGame.js
+++ b/src/functions/FishingGame.js
@@ -8,7 +8,7 @@ const Database = require("../utils/Database");
 const AdminUtils = require("../utils/AdminUtils");
 const sdModule = require("./ComfyUICommands");
 const ReturnMessage = require("../models/ReturnMessage");
-const SlotsGame = require("./SlotsGame");
+
 
 const logger = new Logger("fishing-game");
 
@@ -1143,7 +1143,7 @@ async function applyItemEffect(userData, item) {
 					effectMessage = `\n\n${item.emoji} Você encontrou um ${item.name}! +${item.value} iscas adicionadas (${userData.baits}/${MAX_BAITS}).`;
 					break;
 				case "slots_coins":
-					await SlotsGame.addCoins(userData.userId, item.value);
+					await require("./SlotsGame").addCoins(userData.userId, item.value);
 					effectMessage = `\n\n${item.emoji} Você encontrou um ${item.name}! +${item.value} moedinhas adicionadas ao seu saldo do !slots.`;
 					break;
 			}


### PR DESCRIPTION
This pull request makes a minor change to how the `SlotsGame` module is imported and used within `src/functions/FishingGame.js`. The static import of `SlotsGame` is removed, and instead, the module is dynamically required only when needed in the `applyItemEffect` function. This helps optimize module loading and avoids unnecessary imports.

Most important change:

* Refactored the usage of `SlotsGame` by removing the top-level import and requiring it dynamically inside the `applyItemEffect` function when adding coins for the "slots_coins" effect. [[1]](diffhunk://#diff-6064b8eb229ed0c2d88fb3c69b75133fd3a46fea6c06f9b95156b97f6dff618cL11-R11) [[2]](diffhunk://#diff-6064b8eb229ed0c2d88fb3c69b75133fd3a46fea6c06f9b95156b97f6dff618cL1146-R1146)